### PR TITLE
Replace spin with helicity according to edm4hep changes

### DIFF
--- a/scripts/compare_sim_outputs.py
+++ b/scripts/compare_sim_outputs.py
@@ -10,8 +10,8 @@ import sys
 members_dict = {
     "MCParticle": {
         "continuous": ["Charge", "Mass", "Time"],
-        "discrete": ["PDG", "GeneratorStatus", "SimulatorStatus"],
-        "vector": ["Momentum", "Vertex", "Endpoint", "MomentumAtEndpoint", "Spin"],
+        "discrete": ["PDG", "GeneratorStatus", "SimulatorStatus", "Helicity"],
+        "vector": ["Momentum", "Vertex", "Endpoint", "MomentumAtEndpoint"],
     },
     "CaloHitContribution": {
         "continuous": ["Energy", "Time"],


### PR DESCRIPTION
BEGINRELEASENOTES
- Quick fix for `run_exact_comparison` stage of [k4-validation script](https://gitlab.cern.ch/aloeschc/k4-validation/-/blob/master/.gitlab-ci.yml?ref_type=heads#L216) failing:
    - replace spin (Vector member) with helicity (integer) as was done in [edm4hep PR #404](https://github.com/key4hep/EDM4hep/pull/404)

ENDRELEASENOTES

Successfully tested workflow locally 