### PR TITLE
Replace getMCParticle with getParticle

### DIFF
--- a/scripts/FCCee/CLD/ARC_make_hists.py
+++ b/scripts/FCCee/CLD/ARC_make_hists.py
@@ -69,7 +69,7 @@ def make_hists_file(args):
         theta_1stHit = mom.Theta()
 
         for arc_hit in event.get("ArcCollection"):
-            particle = arc_hit.getMCParticle()
+            particle = arc_hit.getParticle()
             pdgID = particle.getPDG()
             if pdgID in (22, -22):
                 n_ph += 1


### PR DESCRIPTION
BEGINRELEASENOTES
- replace `getMCParticle()` with `getParticle()` in ARC script, to fix failing test

ENDRELEASENOTES
